### PR TITLE
Update REVRobotics SparkMax to 1.5.2 SDK (#83)

### DIFF
--- a/vendordeps/REVRobotics.json
+++ b/vendordeps/REVRobotics.json
@@ -1,7 +1,7 @@
 {
     "fileName": "REVRobotics.json",
     "name": "REVRobotics",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
         "http://www.revrobotics.com/content/sw/max/sdk/maven/"
@@ -11,14 +11,14 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "SparkMax-java",
-            "version": "1.5.1"
+            "version": "1.5.2"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "SparkMax-driver",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -35,7 +35,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "SparkMax-cpp",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "libName": "SparkMax",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -52,7 +52,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "SparkMax-driver",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "libName": "SparkMaxDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
Fixes crashes during simulation, and likely crashes during competition if too man CAN bug errors happen quickly.